### PR TITLE
Gracefully handle shutdown requests and exit

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -24,3 +24,19 @@ server.get('/', (req, res) => {
 server.listen(config.http.port, config.http.host, () => {
   global.logger.info('%s listening at %s', server.name, server.url);
 });
+
+
+// gracefully handle shutdowns -----------------------
+
+const closeGracefully = (signal) => {
+  setTimeout(() => {
+    global.logger.warn('Forcefully shutting down from sig:', signal);
+    process.exit(0); // eslint-disable-line no-process-exit
+  }, 500);
+
+  server.close(() => process.exit(0)); // eslint-disable-line no-process-exit
+};
+
+['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach(signal =>
+  process.on(signal, () => closeGracefully(signal))
+);


### PR DESCRIPTION
This should probably be moved to the `lev-restify` module, but for now I need a quick fix, because I think this is causing a VERY long `crashloop-backoff` phase in kube deployments. See the below for more details:
```bash
docker run lev-report -d
docker exec -ti lev-report sh
/app $ kill -9 1
/app $ kill -9 1
/app $ kill -9 1
/app $ ps -ef
PID   USER     TIME  COMMAND
    1 app       0:00 node .
   17 app       0:00 sh
   25 app       0:00 ps -ef
```