### PR TITLE
Fix: Only copy images when they are present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN npm install --only production > .npm-install.log 2>&1 \
  && rm .npm-install.log \
  || ( EC=$?; cat .npm-install.log; exit $EC )
 
-COPY assets/ /app/assets/
-COPY pages/ /app/pages/
-COPY src/ /app/src/
+COPY --chown=app assets/ /app/assets/
+COPY --chown=app pages/ /app/pages/
+COPY --chown=app src/ /app/src/
 
 RUN npm run postinstall
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "test:ui": "eslint assets/js",
     "watch:server": "nodemon -w src -w test/server -x 'npm run test:server'",
     "watch:ui": "nodemon -w src -w test -x 'npm run test:server'",
+    "copy:images": "if [ -e ./assets/images ]; then cp -r ./assets/images ./public/; fi",
     "browserify": "if [ -e ./assets/js/app.js ]; then browserify ./assets/js/app.js > ./public/js/bundle.js; fi",
-    "postinstall": "mkdir -p public/js public/css && cp -r assets/images public/ && npm run browserify"
+    "postinstall": "mkdir -p public/js public/css && npm run copy:images && npm run browserify"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "test:ui": "eslint assets/js",
     "watch:server": "nodemon -w src -w test/server -x 'npm run test:server'",
     "watch:ui": "nodemon -w src -w test -x 'npm run test:server'",
-    "copy:images": "if [ -e ./assets/images ]; then cp -r ./assets/images ./public/; fi",
-    "browserify": "if [ -e ./assets/js/app.js ]; then browserify ./assets/js/app.js > ./public/js/bundle.js; fi",
-    "postinstall": "mkdir -p public/js public/css && npm run copy:images && npm run browserify"
+    "copy:images": "cp -r ./assets/images ./public/",
+    "browserify": "browserify ./assets/js/app.js > ./public/js/bundle.js",
+    "postinstall": "if [ -e ./assets ]; then mkdir -p public/js public/css && npm run copy:images && npm run browserify ; fi"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
They are NOT present in the Docker build on the first call of `npm
install` they are only present for the second call.