### PR TITLE
[LEVWEB-1369] Hourly usage chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -861,6 +861,12 @@
         "check-error": "^1.0.2"
       }
     },
+    "chai-each": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/chai-each/-/chai-each-0.0.1.tgz",
+      "integrity": "sha512-W0G98eDRmV4ahXjGBXHsljhXU2MBLQquP2Eo+oOikqywGO0QLYK8tBUKkFGwl7KPQWeeQPLssvRbQXFsIk6Xlg==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bunyan": "^1.8.12",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "chai-each": "0.0.1",
     "eslint": "^6.8.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-mocha": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/runtime": "^7.6.3",
     "bluebird": "^3.5.4",
     "browserify": "^16.2.3",
-    "lev-react-components": "^0.7.0",
+    "lev-react-components": "^0.8.0",
     "lev-react-renderer": "^0.1.0",
     "lev-restify": "^1.0.0",
     "moment": "^2.24.0",

--- a/src/lib/model.js
+++ b/src/lib/model.js
@@ -55,12 +55,47 @@ const processGroups = data => data.reduce(
   , []);
 const groupUsage = (dateFrom, dateTo) => query.usageByGroup(dateFrom, dateTo).then(processGroups);
 
+const hours = (name, colour) => ({
+  name,
+  data: Array.from({ length: 24 }, (_, n) => ({ count: 0, hour: n })),
+  colour
+});
+const dayCounts = (from, to) => {
+  const start = moment(from, DATE_FORMAT);
+  const end = moment(to, DATE_FORMAT);
+
+  const diff = Math.abs(Math.round(moment.duration(start.startOf('day').diff(end.endOf('day'))).as('days')));
+
+  const mod = diff % 7;
+  const weeks = Math.floor(diff / 7);
+  const startDay = start.day() || 7;
+  const extraWeekEndDays = mod && [6, 7].filter(n => startDay <= n && (startDay + mod) > n).length;
+  const we = (weeks * 2) + extraWeekEndDays;
+
+  return [diff - we, we];
+};
+const processHourlyUsage = (nod, data) => {
+  const total = nod[0] + nod[1];
+  const traces = [nod[0] && hours('weekday'), nod[1] && hours('weekend')];
+  const average = hours('average').data;
+  data.forEach(d => {
+    traces[d.weekend].data[d.hour].count = (d.count / nod[d.weekend]);
+    average[d.hour].count += d.count;
+  });
+  return [...traces, nod[0] && nod[1] && {
+    name: 'average', data: average.map(o => ({ ...o, count: o.count / total }))
+  }].filter(e => e);
+};
+const hourlyUsage = (dateFrom, dateTo, searchGroup) => query.hourlyUsage(dateFrom, dateTo, searchGroup)
+  .then(processHourlyUsage.bind(null, dayCounts(dateFrom, dateTo || moment().endOf('day'))));
+
 const build = (dateFrom, dateTo, searchGroup, groupSearchText) => Promise.join(
   dailyUsage(dateFrom, dateTo, searchGroup),
   datasetUsage(dateFrom, dateTo),
   groupUsage(dateFrom, dateTo),
   query.searchTimePeriodByGroup(dateFrom, dateTo, searchGroup),
-  (daily, totals, groups, total) => ({
+  hourlyUsage(dateFrom, dateTo, searchGroup),
+  (daily, totals, groups, total, hourly) => ({
     from: dateFrom,
     to: dateTo,
     dates: datesInRange(dateFrom, dateTo || moment().endOf('day')),
@@ -68,8 +103,10 @@ const build = (dateFrom, dateTo, searchGroup, groupSearchText) => Promise.join(
     groups,
     totals,
     currentGroup: groupSearchText,
-    total
+    total,
+    hourlyUsage: hourly
   })
 );
 
 module.exports = build;
+module.exports.hourlyUsage = hourlyUsage;

--- a/src/lib/model.js
+++ b/src/lib/model.js
@@ -76,14 +76,14 @@ const dayCounts = (from, to) => {
 };
 const processHourlyUsage = (nod, data) => {
   const total = nod[0] + nod[1];
-  const traces = [nod[0] && hours('weekday'), nod[1] && hours('weekend')];
-  const average = hours('average').data;
+  const traces = [nod[0] && hours('weekday', '#2746B9'), nod[1] && hours('weekend', '#31BB76')];
+  const average = hours('average', '#0B69D4');
   data.forEach(d => {
     traces[d.weekend].data[d.hour].count = (d.count / nod[d.weekend]);
-    average[d.hour].count += d.count;
+    average.data[d.hour].count += d.count;
   });
   return [...traces, nod[0] && nod[1] && {
-    name: 'average', data: average.map(o => ({ ...o, count: o.count / total }))
+    ...average, data: average.data.map(o => ({ ...o, count: o.count / total }))
   }].filter(e => e);
 };
 const hourlyUsage = (dateFrom, dateTo, searchGroup) => query.hourlyUsage(dateFrom, dateTo, searchGroup)

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -9,6 +9,6 @@ globals:
 rules:
   func-names: 0
   max-nested-callbacks: 0
-  no-unused-expressions: 0
+  no-unused-expressions: 1
   no-process-env: 0
-  no-console: 0
+  no-console: 1

--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,6 @@
 'use strict';
 
-global.chai = require('chai').use(require('chai-as-promised')).use(require('sinon-chai'));
+global.chai = require('chai').use(require('chai-as-promised')).use(require('sinon-chai')).use(require('chai-each'));
 global.assert = chai.assert;
 global.expect = chai.expect;
 global.should = chai.should();

--- a/test/server/lib/db/query.fixtures.js
+++ b/test/server/lib/db/query.fixtures.js
@@ -80,5 +80,36 @@ WHERE date_time >= $(from) AND date_time < $(to) AND groups::TEXT ILIKE '%' || $
     gorupOnlySQL: `SELECT count(*)::INTEGER
 FROM lev_audit
 WHERE groups::TEXT ILIKE '%' || $(group) || '%'`
+  },
+  hourlyUsage: {
+    // NOTE: the following query would take around 30 SECONDS to complete, so will 502
+    // It may be possible to re-include this kind full data request once the the
+    // underlying infrastructure can handle it, and we deem it useful!
+//     noParameterSQL: `SELECT COUNT(*)::INTEGER, weekend::INTEGER, hour
+// FROM (
+//   SELECT TO_CHAR(date_time AT TIME ZONE 'europe/london', 'HH24')::INTEGER AS hour,
+//     TO_CHAR(date_time AT TIME ZONE 'europe/london', 'DAY') LIKE 'S%' AS weekend
+//   FROM lev_audit
+//   WHERE groups::TEXT NOT ILIKE '%monitor%' AND client = 'lev-web'
+// ) AS counts
+// GROUP BY weekend, hour`,
+
+    fromDateOnlySQL: `SELECT COUNT(*)::INTEGER, weekend::INTEGER, hour
+FROM (
+  SELECT TO_CHAR(date_time AT TIME ZONE 'europe/london', 'HH24')::INTEGER AS hour,
+    TO_CHAR(date_time AT TIME ZONE 'europe/london', 'DAY') LIKE 'S%' AS weekend
+  FROM lev_audit
+  WHERE date_time >= $(from) AND groups::TEXT NOT LIKE '/Monitor%' AND client = 'lev-web'
+) AS counts
+GROUP BY weekend, hour`,
+
+    allParametersSQL: `SELECT COUNT(*)::INTEGER, weekend::INTEGER, hour
+FROM (
+  SELECT TO_CHAR(date_time AT TIME ZONE 'europe/london', 'HH24')::INTEGER AS hour,
+    TO_CHAR(date_time AT TIME ZONE 'europe/london', 'DAY') LIKE 'S%' AS weekend
+  FROM lev_audit
+  WHERE date_time >= $(from) AND date_time < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%'
+) AS counts
+GROUP BY weekend, hour`
   }
 };

--- a/test/server/lib/model.fixtures.js
+++ b/test/server/lib/model.fixtures.js
@@ -1,0 +1,69 @@
+'use strict';
+
+module.exports = {
+  data: {
+    hourlyUsage: [
+      {count: 12, weekend: 1, hour: 7},
+      {count: 183, weekend: 1, hour: 8},
+      {count: 242, weekend: 1, hour: 9},
+      {count: 221, weekend: 1, hour: 10},
+      {count: 289, weekend: 1, hour: 11},
+      {count: 172, weekend: 1, hour: 12},
+      {count: 189, weekend: 1, hour: 13},
+      {count: 151, weekend: 1, hour: 14},
+      {count: 117, weekend: 1, hour: 15},
+      {count: 377, weekend: 0, hour: 7},
+      {count: 1254, weekend: 0, hour: 8},
+      {count: 3825, weekend: 0, hour: 9},
+      {count: 6202, weekend: 0, hour: 10},
+      {count: 7362, weekend: 0, hour: 11},
+      {count: 6003, weekend: 0, hour: 12},
+      {count: 5203, weekend: 0, hour: 13},
+      {count: 4467, weekend: 0, hour: 14},
+      {count: 3061, weekend: 0, hour: 15},
+      {count: 1447, weekend: 0, hour: 16},
+      {count: 612, weekend: 0, hour: 17},
+      {count: 217, weekend: 0, hour: 18},
+      {count: 155, weekend: 0, hour: 19},
+      {count: 28, weekend: 0, hour: 20},
+      {count: 11, weekend: 0, hour: 21}
+    ]
+  },
+
+  results: {
+    hourlyUsage: [
+      { name: 'weekday', data: [
+          { hour: 0, count: 0 }, { hour: 1, count: 0 }, { hour: 2, count: 0 }, { hour: 3, count: 0 },
+          { hour: 4, count: 0 }, { hour: 5, count: 0 }, { hour: 6, count: 0 },
+          { hour: 7, count: 377/5.0 }, { hour: 8, count: 1254/5.0 }, { hour: 9, count: 3825/5 },
+          { hour: 10, count: 6202/5.0 }, { hour: 11, count: 7362/5.0 }, { hour: 12, count: 6003/5.0 },
+          { hour: 13, count: 5203/5.0 }, { hour: 14, count: 4467/5.0 }, { hour: 15, count: 3061/5.0 },
+          { hour: 16, count: 1447/5.0 }, { hour: 17, count: 612/5.0 }, { hour: 18, count: 217/5.0 },
+          { hour: 19, count: 155/5.0 }, { hour: 20, count: 28/5.0 }, { hour: 21, count: 11/5.0 },
+          { hour: 22, count: 0 }, { hour: 23, count: 0 }
+        ]
+      },
+      { name: 'weekend', data: [
+          { hour: 0, count: 0 }, { hour: 1, count: 0 }, { hour: 2, count: 0 }, { hour: 3, count: 0 },
+          { hour: 4, count: 0 }, { hour: 5, count: 0 }, { hour: 6, count: 0 },
+          { hour: 7, count: 12/2 }, { hour: 8, count: 183/2.0 }, { hour: 9, count: 242/2 },
+          { hour: 10, count: 221/2.0 }, { hour: 11, count: 289/2.0 }, { hour: 12, count: 172/2 },
+          { hour: 13, count: 189/2.0 }, { hour: 14, count: 151/2.0 }, { hour: 15, count: 117/2.0 },
+          { hour: 16, count: 0 }, { hour: 17, count: 0 }, { hour: 18, count: 0 }, { hour: 19, count: 0 },
+          { hour: 20, count: 0 }, { hour: 21, count: 0 }, { hour: 22, count: 0 }, { hour: 23, count: 0 }
+        ]
+      },
+      { name: 'average', data: [
+          { hour: 0, count: 0 }, { hour: 1, count: 0 }, { hour: 2, count: 0 }, { hour: 3, count: 0 },
+          { hour: 4, count: 0 }, { hour: 5, count: 0 }, { hour: 6, count: 0 },
+          { hour: 7, count: (377+12)/7.0 }, { hour: 8, count: (1254+183)/7.0 }, { hour: 9, count: (3825+242)/7.0 },
+          { hour: 10, count: (6202+221)/7.0 }, { hour: 11, count: (7362+289)/7.0 }, { hour: 12, count: (6003+172)/7.0 },
+          { hour: 13, count: (5203+189)/7.0 }, { hour: 14, count: (4467+151)/7.0 }, { hour: 15, count: (3061+117)/7.0 },
+          { hour: 16, count: 1447/7.0 }, { hour: 17, count: 612/7.0 }, { hour: 18, count: 217/7.0 },
+          { hour: 19, count: 155/7.0 }, { hour: 20, count: 28/7.0 }, { hour: 21, count: 11/7.0 },
+          { hour: 22, count: 0 }, { hour: 23, count: 0 }
+        ]
+      }
+    ]
+  }
+};

--- a/test/server/lib/model.js
+++ b/test/server/lib/model.js
@@ -91,7 +91,7 @@ describe('lib/model', () => {
 
       it('should return an array of 24 items', () =>
         expect(hours('title'))
-          .to.be.an('object').that.has.keys(['name', 'data'])
+          .to.be.an('object').that.has.keys(['name', 'data', 'colour'])
           .and.property('data').to.be.an('array').that.has.lengthOf(24)
       );
 

--- a/test/server/lib/model.js
+++ b/test/server/lib/model.js
@@ -1,8 +1,13 @@
 'use strict';
 
 const moment = require('moment');
-const rewire = require('rewire');
-const model = rewire('../../../src/lib/model');
+const proxyquire = require('proxyquire');
+const { data, results } = require('./model.fixtures');
+const model = require('rewire')('../../../src/lib/model');
+const stub = sinon.stub();
+const { hourlyUsage } = proxyquire('../../../src/lib/model', {
+  './db/query': { hourlyUsage: stub }
+});
 
 describe('lib/model', () => {
   describe('helper function', () => {
@@ -66,5 +71,88 @@ describe('lib/model', () => {
       });
     });
 
+    describe('dayCounts', () => {
+      const dayCounts = model.__get__('dayCounts');
+
+      it('should take start date "2020-03-11", end date "2020-03-11" and return "{week:1,end:0}"', () =>
+        expect(dayCounts('2020-03-11', '2020-03-11')).to.deep.equal([1, 0]));
+      it('should take start date "2020-03-14", end date "2020-03-14" and return "{week:0,end:1}"', () =>
+        expect(dayCounts('2020-03-14', '2020-03-14')).to.deep.equal([0, 1]));
+      it('should take start date "2020-03-11", end date "2020-03-12" and return "{week:2,end:0}"', () =>
+        expect(dayCounts('2020-03-11', '2020-03-12')).to.deep.equal([2, 0]));
+      it('should take start date "2020-03-14", end date "2020-03-15" and return "{week:0,end:2}"', () =>
+        expect(dayCounts('2020-03-14', '2020-03-15')).to.deep.equal([0, 2]));
+      it('should take start date "2020-03-09", end date "2020-03-15" and return "{week:0,end:2}"', () =>
+        expect(dayCounts('2020-03-09', '2020-03-15')).to.deep.equal([5, 2]));
+    });
+
+    describe('hours', () => {
+      const hours = model.__get__('hours');
+
+      it('should return an array of 24 items', () =>
+        expect(hours('title'))
+          .to.be.an('object').that.has.keys(['name', 'data'])
+          .and.property('data').to.be.an('array').that.has.lengthOf(24)
+      );
+
+      it('should have an object for each hour of the day, with a count of 0', () =>
+        hours().data.forEach((h, n) => expect(h)
+          .to.deep.equal({ count: 0, hour: n}))
+      );
+    });
+  });
+
+  describe('hourlyUsage', () => {
+    before('setup stub', () => {
+      stub.returns(Promise.resolve([
+        { count: 5, weekend: 0, hour: 9 },
+        { count: 12, weekend: 0, hour: 12 },
+        { count: 15, weekend: 0, hour: 13 }
+      ]));
+    });
+
+    let result = false;
+    it('should return an array of trace objects', () =>
+      expect(result = hourlyUsage('2020-01-01', '2020-01-01')).to.eventually.be.an('array'));
+    it('should have a name field for each object', () => result.then(traces =>
+      expect(traces).to.each.have.a.property('name', 'weekday'))
+    );
+
+    describe('trace objects', () => {
+      it('should have an array of data, with a count for each hour', () => result.then(traces =>
+        expect(traces)
+          .each.to.have.a.property('data')
+          .that.has.lengthOf(24)
+          .and.deep.equals([{ hour: 0, count: 0 }, { hour: 1, count: 0 }, { hour: 2, count: 0 }, { hour: 3, count: 0 },
+            { hour: 4, count: 0 }, { hour: 5, count: 0 }, { hour: 6, count: 0 }, { hour: 7, count: 0 },
+            { hour: 8, count: 0 }, { hour: 9, count: 5 }, { hour: 10, count: 0 }, { hour: 11, count: 0 },
+            { hour: 12, count: 12 }, { hour: 13, count: 15 }, { hour: 14, count: 0 }, { hour: 15, count: 0 },
+            { hour: 16, count: 0 }, { hour: 17, count: 0 }, { hour: 18, count: 0 }, { hour: 19, count: 0 },
+            { hour: 20, count: 0 }, { hour: 21, count: 0 }, { hour: 22, count: 0 }, { hour: 23, count: 0 }
+          ])
+      ));
+    });
+
+    describe('fixtures', () => {
+      const lastWeek = moment().add(-7, 'days');
+      const yesterday = moment().add(-1, 'days');
+      before('setup stub', () => {
+        stub.returns(Promise.resolve(data.hourlyUsage));
+        return hourlyUsage(lastWeek, yesterday).then(data => result = data);
+      });
+      it('should produce the fixture result', () => {
+        expect(result).to.be.an('array');
+        expect(result).to.each.have.property('name');
+        expect(result).to.have.nested.property('[0].name', results.hourlyUsage[0].name);
+        expect(result).to.have.nested.property('[1].name', results.hourlyUsage[1].name);
+        expect(result).to.have.nested.property('[2].name', results.hourlyUsage[2].name);
+        expect(result).to.have.nested.property('[0].data').that.deep.equals(results.hourlyUsage[0].data);
+        expect(result).to.have.nested.property('[1].data').that.deep.equals(results.hourlyUsage[1].data);
+        expect(result).to.have.nested.property('[2].data').that.deep.equals(results.hourlyUsage[2].data);
+      });
+      it('should produce the fixture result', () =>
+        expect(hourlyUsage(lastWeek, yesterday)).to.eventually.deep.equal(results.hourlyUsage)
+      );
+    });
   });
 });


### PR DESCRIPTION
NOTE: WIP'd until the dependent `lev-react-components` [PR](https://github.com/UKHomeOffice/lev-react-components/pull/11) is merged and the module published to npm. Then update the version in `package.json` and run `npm i`, commit package/package-lock here, then merge.

Provides data support for the new hourly usage chart, which has been added to the `lev-report` page.
![image](https://user-images.githubusercontent.com/7834222/80919113-3abc0980-8d60-11ea-8d07-9bf3d62b3e7c.png)

The BRM graph is usually a bit more **dynamic**!..
![image](https://user-images.githubusercontent.com/7834222/80919201-b027da00-8d60-11ea-8f70-b0d8b4da1e63.png)
