### PR TITLE
Revert "[LEVWEB-1376] Add timezone to search"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-report",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "description": "Reports showing usage of LEV.",
   "main": "src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-report",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Reports showing usage of LEV.",
   "main": "src/server.js",
   "scripts": {

--- a/src/lib/db/query.js
+++ b/src/lib/db/query.js
@@ -2,19 +2,17 @@
 
 const db = require('./postgres');
 
-const timeZone = 'AT TIME ZONE \'europe/london\'';
-const DTZ = `(date_time ${timeZone})::DATE`;
-const countsByType = `SELECT dataset, count(*)::INTEGER FROM lev_audit WHERE ${DTZ} > $(from)`;
+const countsByType = 'SELECT dataset, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from)';
 const countsByUser =
-  `SELECT ${DTZ} AS date, dataset, username, count(*)::INTEGER FROM lev_audit WHERE ${DTZ} > $(from)`;
-const until = `AND ${DTZ} < $(to)`;
+  'SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from)';
+const until = 'AND date_time < $(to)';
 const groupByType = ' GROUP BY dataset';
-const groupByDateTypeUser = ' GROUP BY 1, 2, 3 ORDER BY 1';
+const groupByDateTypeUser = ' GROUP BY date_time::date, dataset, username ORDER BY date_time::date';
 const groupByTypeGroup = 'GROUP BY name, dataset';
 const totalCount = 'SELECT count(*)::INTEGER FROM lev_audit';
-const forToday = ` WHERE (CURRENT_TIMESTAMP ${timeZone})::DATE = ${DTZ};`;
-const fromDate = `${DTZ} >= $(from)`;
-const toDate = `${DTZ} < $(to)`;
+const forToday = ' WHERE date_time::DATE = current_date';
+const fromDate = 'date_time::DATE >= $(from)';
+const toDate = 'date_time::DATE < $(to)';
 const searchGroup = 'groups::TEXT ILIKE \'%\' || $(group) || \'%\'';
 
 const buildCountsByGroup = (from, to, includeNoGroup = true) => `
@@ -22,12 +20,12 @@ SELECT name, dataset, SUM(count)::INTEGER AS count
 FROM (
   SELECT UNNEST(groups) AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE ${DTZ} > $(from) ${to ? until : ''}
+    WHERE date_time > $(from) ${to ? until : ''}
     ${groupByTypeGroup} ${includeNoGroup ? `
   UNION
   SELECT 'No group' AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE groups='{}' AND ${DTZ} > $(from) ${to ? until : ''}` : ''}
+    WHERE groups='{}' AND date_time > $(from) ${to ? until : ''}` : ''}
     ${groupByTypeGroup}
 ) AS counts
 ${groupByTypeGroup}
@@ -45,11 +43,10 @@ const sqlBuilder = (obj) => {
 module.exports = {
   usageByDateType: (from, to, group) => db.manyOrNone(
     sqlBuilder({
-      'SELECT': `${DTZ} AS date, dataset, count(*)::INTEGER`,
+      'SELECT': 'date_time::DATE AS date, dataset, count(*)::INTEGER',
       'FROM': 'lev_audit',
       'WHERE': [from && fromDate, to && toDate, group && searchGroup],
-      'GROUP BY': '1, 2',
-      'ORDER BY': '1'
+      'GROUP BY': 'date_time::date, dataset ORDER BY date_time::date'
     }),
     filterObject({ from: from, to: to, group: group }))
     .catch(e => {

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -176,8 +176,7 @@ describe('lib/db/query', () => {
 			it('should build an sql statement when `to, from and group` are provided', () =>
 				expect(stub).to.have.been.calledOnce
 					.and.to.have.been.calledWith('SELECT count(*)::INTEGER FROM lev_audit ' +
-					'WHERE (date_time AT TIME ZONE \'europe/london\')::DATE >= $(from) AND ' +
-					'(date_time AT TIME ZONE \'europe/london\')::DATE < $(to) ' +
+					'WHERE date_time::DATE >= $(from) AND date_time::DATE < $(to) ' +
 					'AND groups::TEXT ILIKE \'%\' || $(group) || \'%\'')
 			);
 		});


### PR DESCRIPTION
Reverts UKHomeOffice/lev-report#34

The timezone tinkering in the SQL queries seems to have a slight negative effect. Let's revert these changes, and solve this problem another way instead...