### PR TITLE
[LEVWEB-1376] Use full exact timestamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-report",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -285,9 +285,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         },
         "acorn-walk": {
@@ -2736,9 +2736,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -3095,18 +3095,11 @@
       "integrity": "sha512-tilCZOvIhRETXJuTmxxpz8mgplF7gmFhcH05JuR/YL+JLO98gLRQ1Mk4XpYQxxbPMKupSOv+Bidw7EKv8wds1w=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -3271,6 +3264,14 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
+      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "ms": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-report",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5345,6 +5345,12 @@
         "es5-ext": "~0.10.46",
         "next-tick": "1"
       }
+    },
+    "timeshift": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/timeshift/-/timeshift-0.0.2.tgz",
+      "integrity": "sha512-/anBRRWdb+1nZ/5xGYdAAm9x2FiOfYIJ2swhcZVR1nivChNa6Dry+6laTY3NWJDE5UpiwxKpSIXf7rh/XwNq8A==",
+      "dev": true
     },
     "tiny-invariant": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lev-react-renderer": "^0.1.0",
     "lev-restify": "^1.0.0",
     "moment": "^2.24.0",
+    "moment-timezone": "^0.5.28",
     "pg-monitor": "^1.1.0",
     "pg-promise": "^8.6.4",
     "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node ./src/server.js",
-    "dev": "nodemon -w ./assets/js -x 'npm run test:ui && npm run browserify' & MOCK=true nodemon -w ./src -w ./public -w ./node_modules/lev-react-components/dist/index.js ./src/server.js",
+    "dev": "nodemon -w ./assets/js -x 'npm run test:ui && npm run browserify' & MOCK=${MOCK:-true} nodemon -w ./src -w ./public -w ./node_modules/lev-react-components/dist/index.js ./src/server.js",
     "test": "npm run test:ui && npm run test:server",
     "test:server": "eslint src && mocha test/server",
     "test:ui": "eslint assets/js",
     "watch:server": "nodemon -w src -w test/server -x 'npm run test:server'",
-    "watch:ui": "nodemon -w src -w test -x 'npm run test:server'",
+    "watch:ui": "nodemon -w src -w test -x 'npm run test:ui'",
     "copy:images": "cp -r ./assets/images ./public/",
     "browserify": "browserify ./assets/js/app.js > ./public/js/bundle.js",
     "postinstall": "if [ -e ./assets ]; then mkdir -p public/js public/css && npm run copy:images && npm run browserify ; fi"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-report",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Reports showing usage of LEV.",
   "main": "src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "proxyquire": "^2.1.0",
     "rewire": "^5.0.0",
     "sinon": "^7.3.2",
-    "sinon-chai": "^3.3.0"
+    "sinon-chai": "^3.3.0",
+    "timeshift": "0.0.2"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,16 +1,18 @@
 'use strict';
 
+const defaultsFalse = v => String(v || '').match(/(true|yes|on)/i) !== null;
+
 /* eslint-disable no-process-env */
 module.exports = {
   name: require('../package').name,
   postgres: {
-    mock: process.env.MOCK,
+    mock: defaultsFalse(process.env.MOCK),
     user: process.env.POSTGRES_USER || 'postgres',
     password: process.env.POSTGRES_PASSWORD || 'postgres',
     host: process.env.POSTGRES_HOST || 'localhost',
     port: process.env.POSTGRES_PORT || '5432',
     database: process.env.POSTGRES_DB || 'lev',
-    ssl: process.env.POSTGRES_SSL || false
+    ssl: defaultsFalse(process.env.POSTGRES_SSL)
   },
   http: {
     host: process.env.LISTEN_HOST || '0.0.0.0',

--- a/src/lib/db/query.js
+++ b/src/lib/db/query.js
@@ -5,8 +5,8 @@ const db = require('./postgres');
 const groupByTypeGroup = 'GROUP BY name, dataset';
 const totalCount = 'SELECT count(*)::INTEGER FROM lev_audit';
 const forToday = ' WHERE date_time >= (current_date::date)::timestamp';
-const fromDate = 'date_time >= ($(from)::timestamp without time zone) at time zone \'Europe/London\'';
-const toDate = 'date_time < ($(to)::timestamp without time zone) at time zone \'Europe/London\'';
+const fromDate = 'date_time >= $(from)';
+const toDate = 'date_time < $(to)';
 const searchGroup = 'groups::TEXT ILIKE \'%\' || $(group) || \'%\'';
 
 const buildCountsByGroup = (from, to, includeNoGroup = true) => `

--- a/src/lib/db/query.js
+++ b/src/lib/db/query.js
@@ -33,11 +33,11 @@ ORDER BY name~'^/Team' desc, name`;
 
 const filterObject = (obj) => Object.fromEntries(Object.entries(obj).filter(e => e[1]));
 
-const sqlBuilder = (obj) => {
+const sqlBuilder = (obj, joiner) => {
   obj = filterObject(obj);
     return Object.entries(obj).map(([key, value]) =>
       `${key} ${Array.isArray(value) ? value.filter(e => e).join(' AND ') : value}`
-    ).join(' ');
+    ).join(joiner || ' ');
 };
 
 module.exports = {
@@ -90,7 +90,7 @@ module.exports = {
         'SELECT': 'count(*)::INTEGER',
         'FROM': 'lev_audit',
         'WHERE': [from && fromDate, to && toDate, group && searchGroup]
-      }),
+      }, '\n'),
       filterObject({ from, to, group }),
       data => data.count
     )

--- a/src/lib/model.js
+++ b/src/lib/model.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Promise = require('bluebird');
 const moment = require('moment');
 const config = require('../config');
 const query = config.postgres.mock ? require('../../mock/mock-query') : require('./db/query');

--- a/src/lib/route-helpers.js
+++ b/src/lib/route-helpers.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const dateFormat = 'YYYY-MM-DD';
+const moment = require('moment-timezone');
+const model = require('./model');
+const dashboardModel = require('./dashboard-model');
+
+const promiseResponder = (promise, req, res, next, component) => promise
+  .then(data => component ? res.render(component, data) : res.send(data))
+  .catch(err => {
+    req.log.error(err);
+    return next(err);
+  });
+
+const dateChecker = (d) => !!d && moment.tz(d, dateFormat, true, 'Europe/London').toISOString();
+
+const home = (query, ErrorReporter) => {
+  const fromDate = dateChecker(query && query.from);
+  if (ErrorReporter && fromDate === null) {
+    throw new ErrorReporter('Must provide "from" date parameter, and optionally a "to" date');
+  }
+  const toDate = dateChecker(query && query.to);
+  if (ErrorReporter && toDate === null) {
+    throw new ErrorReporter(`Make sure the date format is "${dateFormat}" (time is ignored)`);
+  }
+  const searchGroup = query && query.currentGroup;
+
+  return model(
+    (fromDate ? fromDate : moment.tz('Europe/London').startOf('month').toISOString()),
+    toDate,
+    searchGroup === 'No group' ? '{}' : searchGroup,
+    searchGroup
+  );
+};
+
+module.exports = {
+  promiseResponder,
+  dashboard: dashboardModel,
+  home
+};

--- a/src/lib/route-helpers.js
+++ b/src/lib/route-helpers.js
@@ -5,8 +5,8 @@ const moment = require('moment-timezone');
 const model = require('./model');
 const dashboardModel = require('./dashboard-model');
 
-const promiseResponder = (promise, req, res, next, component) => promise
-  .then(data => component ? res.render(component, data) : res.send(data))
+const promiseResponder = (promise, Component) => (req, res, next) => promise(req.query)
+  .then(data => Component ? res.render(Component, data) : res.send(data))
   .catch(err => {
     req.log.error(err);
     return next(err);
@@ -37,5 +37,6 @@ module.exports = {
   dateChecker,
   promiseResponder,
   dashboard: dashboardModel,
-  home
+  home,
+  homeError: ErrorReporter => req => home(req, ErrorReporter)
 };

--- a/src/lib/route-helpers.js
+++ b/src/lib/route-helpers.js
@@ -12,28 +12,29 @@ const promiseResponder = (promise, req, res, next, component) => promise
     return next(err);
   });
 
-const dateChecker = (d) => !!d && moment.tz(d, dateFormat, true, 'Europe/London').toISOString();
+const dateChecker = (d) => !!d && moment.tz(d, dateFormat, true, 'Europe/London').format();
 
-const home = (query, ErrorReporter) => {
+const home = (query, ErrorReporter) => new Promise((resolve) => {
   const fromDate = dateChecker(query && query.from);
-  if (ErrorReporter && fromDate === null) {
+  if (ErrorReporter && fromDate === 'Invalid date') {
     throw new ErrorReporter('Must provide "from" date parameter, and optionally a "to" date');
   }
   const toDate = dateChecker(query && query.to);
-  if (ErrorReporter && toDate === null) {
+  if (ErrorReporter && toDate === 'Invalid date') {
     throw new ErrorReporter(`Make sure the date format is "${dateFormat}" (time is ignored)`);
   }
   const searchGroup = query && query.currentGroup;
 
-  return model(
-    (fromDate ? fromDate : moment.tz('Europe/London').startOf('month').toISOString()),
+  return resolve(model(
+    (fromDate ? fromDate : moment.tz('Europe/London').startOf('month').format()),
     toDate,
     searchGroup === 'No group' ? '{}' : searchGroup,
     searchGroup
-  );
-};
+  ));
+});
 
 module.exports = {
+  dateChecker,
   promiseResponder,
   dashboard: dashboardModel,
   home

--- a/src/lib/routes.js
+++ b/src/lib/routes.js
@@ -1,50 +1,17 @@
 'use strict';
 
-const dateFormat = 'YYYY-MM-DD HH:mm:ss';
-const moment = require('moment-timezone');
-const model = require('./model');
-const dashboardModel = require('./dashboard-model');
+const { promiseResponder, dashboard, home } = require('./route-helpers');
 const { LevDashboard, LevReport } = require('lev-react-components');
-
-const promiseResponder = (promise, req, res, next, component) => promise
-  .then(data => component ? res.render(component, data) : res.send(data))
-  .catch(err => {
-    req.log.error(err);
-    return next(err);
-  });
-
-const dateChecker = (d, m = moment(d, dateFormat)) => !!d && m.isValid() && m.tz('Europe/London').toISOString();
 
 module.exports = server => {
   server.get('/readiness', (req, res) => res.send('OK'));
 
-  server.get('/data', (req, res, next) => { // eslint-disable-line consistent-return
-    const fromDate = dateChecker(req.query.from);
-    const toDate = dateChecker(req.query && req.query.to);
+  server.get('/data', (req, res, next) =>
+    promiseResponder(home(req.query, server.errors.BadRequestError), req, res, next));
 
-    if (dateChecker(fromDate)) {
-      if (dateChecker(toDate)) {
-        return promiseResponder(model(fromDate, toDate), req, res, next);
-      }
-      return next(new server.errors.BadRequestError(`Make sure the date format is "${dateFormat}" (time is optional)`));
-    }
-    return next(new server.errors.BadRequestError('Must provide "from" date parameter, and optionally a "to" date'));
-  });
+  server.get('/dashboard', (req, res, next) => promiseResponder(dashboard(), req, res, next, LevDashboard));
 
-  server.get('/dashboard', (req, res, next) => promiseResponder(dashboardModel(), req, res, next, LevDashboard));
+  server.get('/dashboard/data', (req, res, next) => promiseResponder(dashboard(), req, res, next));
 
-  server.get('/dashboard/data', (req, res, next) => promiseResponder(dashboardModel(), req, res, next));
-
-  server.get('/*', (req, res, next) => {
-    const fromDate = dateChecker(req.query && req.query.from);
-    const toDate = dateChecker(req.query && req.query.to);
-    const searchGroup = req.query && req.query.currentGroup;
-
-    return promiseResponder(model(
-      (fromDate ? fromDate : moment().startOf('month').tz('Europe/London').toISOString()),
-      toDate,
-      searchGroup === 'No group' ? '{}' : searchGroup,
-      searchGroup
-    ), req, res, next, LevReport);
-  });
+  server.get('/*', (req, res, next) => promiseResponder(home(req.query), req, res, next, LevReport));
 };

--- a/src/lib/routes.js
+++ b/src/lib/routes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const dateFormat = 'YYYY-MM-DD HH:mm:ss';
-const moment = require('moment');
+const moment = require('moment-timezone');
 const model = require('./model');
 const dashboardModel = require('./dashboard-model');
 const { LevDashboard, LevReport } = require('lev-react-components');
@@ -13,7 +13,7 @@ const promiseResponder = (promise, req, res, next, component) => promise
     return next(err);
   });
 
-const dateChecker = d => !!d && moment(d, dateFormat).isValid() && d;
+const dateChecker = (d, m = moment(d, dateFormat)) => !!d && m.isValid() && m.tz('Europe/London').toISOString();
 
 module.exports = server => {
   server.get('/readiness', (req, res) => res.send('OK'));
@@ -41,7 +41,7 @@ module.exports = server => {
     const searchGroup = req.query && req.query.currentGroup;
 
     return promiseResponder(model(
-      (fromDate ? fromDate : moment().startOf('month')),
+      (fromDate ? fromDate : moment().startOf('month').tz('Europe/London').toISOString()),
       toDate,
       searchGroup === 'No group' ? '{}' : searchGroup,
       searchGroup

--- a/src/lib/routes.js
+++ b/src/lib/routes.js
@@ -1,17 +1,16 @@
 'use strict';
 
-const { promiseResponder, dashboard, home } = require('./route-helpers');
+const { promiseResponder, dashboard, home, homeError } = require('./route-helpers');
 const { LevDashboard, LevReport } = require('lev-react-components');
 
 module.exports = server => {
   server.get('/readiness', (req, res) => res.send('OK'));
 
-  server.get('/data', (req, res, next) =>
-    promiseResponder(home(req.query, server.errors.BadRequestError), req, res, next));
+  server.get('/data', promiseResponder(homeError(server.errors.BadRequestError)));
 
-  server.get('/dashboard', (req, res, next) => promiseResponder(dashboard(), req, res, next, LevDashboard));
+  server.get('/dashboard', promiseResponder(dashboard, LevDashboard));
 
-  server.get('/dashboard/data', (req, res, next) => promiseResponder(dashboard(), req, res, next));
+  server.get('/dashboard/data', promiseResponder(dashboard));
 
-  server.get('/*', (req, res, next) => promiseResponder(home(req.query), req, res, next, LevReport));
+  server.get('/*', promiseResponder(home, LevReport));
 };

--- a/test/server/lib/db/query.fixtures.js
+++ b/test/server/lib/db/query.fixtures.js
@@ -25,13 +25,12 @@ GROUP BY dataset`
   },
 
   usageByGroup: {
-    fromDateSQL: `
-SELECT name, dataset, SUM(count)::INTEGER AS count
+    fromDateSQL: `SELECT name, dataset, SUM(count)::INTEGER AS count
 FROM (
   SELECT UNNEST(groups) AS name, dataset, COUNT(*)
     FROM lev_audit
     WHERE date_time >= $(from)
-    GROUP BY name, dataset 
+    GROUP BY name, dataset
   UNION
   SELECT 'No group' AS name, dataset, COUNT(*)
     FROM lev_audit
@@ -40,19 +39,16 @@ FROM (
 ) AS counts
 GROUP BY name, dataset
 ORDER BY name~'^/Team' desc, name`,
-    fromToSQL: `
-SELECT name, dataset, SUM(count)::INTEGER AS count
+    fromToSQL: `SELECT name, dataset, SUM(count)::INTEGER AS count
 FROM (
   SELECT UNNEST(groups) AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE date_time >= $(from)
-      AND date_time < $(to)
-    GROUP BY name, dataset 
+    WHERE date_time >= $(from) AND date_time < $(to)
+    GROUP BY name, dataset
   UNION
   SELECT 'No group' AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE groups='{}' AND date_time >= $(from)
-      AND date_time < $(to)
+    WHERE groups='{}' AND date_time >= $(from) AND date_time < $(to)
     GROUP BY name, dataset
 ) AS counts
 GROUP BY name, dataset

--- a/test/server/lib/db/query.fixtures.js
+++ b/test/server/lib/db/query.fixtures.js
@@ -3,12 +3,12 @@ module.exports = {
   usageByDateType: {
     fromDateOnlySQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= $(from)
+WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
 GROUP BY date, dataset
 ORDER BY date`,
     allParametersSQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= $(from) AND date_time < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%'
+WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London' AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London' AND groups::TEXT ILIKE '%' || $(group) || '%'
 GROUP BY date, dataset
 ORDER BY date`
   },
@@ -16,11 +16,11 @@ ORDER BY date`
   usageByType: {
     fromDateSQL: `SELECT dataset, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= $(from)
+WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
 GROUP BY dataset`,
     fromToSQL: `SELECT dataset, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= $(from) AND date_time < $(to)
+WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London' AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London'
 GROUP BY dataset`
   },
 
@@ -30,12 +30,12 @@ SELECT name, dataset, SUM(count)::INTEGER AS count
 FROM (
   SELECT UNNEST(groups) AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE date_time > $(from) 
+    WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
     GROUP BY name, dataset 
   UNION
   SELECT 'No group' AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE groups='{}' AND date_time > $(from) 
+    WHERE groups='{}' AND date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
     GROUP BY name, dataset
 ) AS counts
 GROUP BY name, dataset
@@ -45,12 +45,14 @@ SELECT name, dataset, SUM(count)::INTEGER AS count
 FROM (
   SELECT UNNEST(groups) AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE date_time > $(from) AND date_time < $(to)
+    WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
+      AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London'
     GROUP BY name, dataset 
   UNION
   SELECT 'No group' AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE groups='{}' AND date_time > $(from) AND date_time < $(to)
+    WHERE groups='{}' AND date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
+      AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London'
     GROUP BY name, dataset
 ) AS counts
 GROUP BY name, dataset
@@ -60,12 +62,12 @@ ORDER BY name~'^/Team' desc, name`
   usageByUser: {
     fromDateSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= $(from)
+WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
 GROUP BY date, dataset, username
 ORDER BY date`,
     fromToSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= $(from) AND date_time < $(to)
+WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London' AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London'
 GROUP BY date, dataset, username
 ORDER BY date`
   },
@@ -78,7 +80,7 @@ ORDER BY date`
   searchTimePeriodByGroup: {
     fromToGroupSQL: `SELECT count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= $(from) AND date_time < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%'`,
+WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London' AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London' AND groups::TEXT ILIKE '%' || $(group) || '%'`,
     gorupOnlySQL: `SELECT count(*)::INTEGER
 FROM lev_audit
 WHERE groups::TEXT ILIKE '%' || $(group) || '%'`

--- a/test/server/lib/db/query.fixtures.js
+++ b/test/server/lib/db/query.fixtures.js
@@ -70,7 +70,7 @@ ORDER BY date`
 
   searchTotals: {
     totalCountSQL: `SELECT count(*)::INTEGER FROM lev_audit`,
-    todayCountSQL: `SELECT count(*)::INTEGER FROM lev_audit WHERE date_time >= (current_date::date)::timestamp`
+    todayCountSQL: `SELECT count(*)::INTEGER FROM lev_audit WHERE date_time >= $(from)`
   },
 
   searchTimePeriodByGroup: {

--- a/test/server/lib/db/query.fixtures.js
+++ b/test/server/lib/db/query.fixtures.js
@@ -1,13 +1,27 @@
 
 module.exports = {
   usageByDateType: {
-    fromDateOnlySQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER FROM lev_audit WHERE date_time::DATE >= $(from) GROUP BY date_time::date, dataset ORDER BY date_time::date`,
-    allParametersSQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER FROM lev_audit WHERE date_time::DATE >= $(from) AND date_time::DATE < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%' GROUP BY date_time::date, dataset ORDER BY date_time::date`
+    fromDateOnlySQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER
+FROM lev_audit
+WHERE date_time >= $(from)
+GROUP BY date, dataset
+ORDER BY date`,
+    allParametersSQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER
+FROM lev_audit
+WHERE date_time >= $(from) AND date_time < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%'
+GROUP BY date, dataset
+ORDER BY date`
   },
 
   usageByType: {
-    fromDateSQL: `SELECT dataset, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from)   GROUP BY dataset`,
-    fromToSQL: `SELECT dataset, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from) AND date_time < $(to)  GROUP BY dataset`
+    fromDateSQL: `SELECT dataset, count(*)::INTEGER
+FROM lev_audit
+WHERE date_time >= $(from)
+GROUP BY dataset`,
+    fromToSQL: `SELECT dataset, count(*)::INTEGER
+FROM lev_audit
+WHERE date_time >= $(from) AND date_time < $(to)
+GROUP BY dataset`
   },
 
   usageByGroup: {
@@ -44,19 +58,27 @@ ORDER BY name~'^/Team' desc, name`
   },
 
   usageByUser: {
-    fromDateSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from)   GROUP BY date_time::date, dataset, username ORDER BY date_time::date`,
-    fromToSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from) AND date_time < $(to)  GROUP BY date_time::date, dataset, username ORDER BY date_time::date`
+    fromDateSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER
+FROM lev_audit
+WHERE date_time >= $(from)
+GROUP BY date, dataset, username
+ORDER BY date`,
+    fromToSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER
+FROM lev_audit
+WHERE date_time >= $(from) AND date_time < $(to)
+GROUP BY date, dataset, username
+ORDER BY date`
   },
 
   searchTotals: {
     totalCountSQL: `SELECT count(*)::INTEGER FROM lev_audit`,
-    todayCountSQL: `SELECT count(*)::INTEGER FROM lev_audit WHERE date_time::DATE = current_date`
+    todayCountSQL: `SELECT count(*)::INTEGER FROM lev_audit WHERE date_time >= (current_date::date)::timestamp`
   },
 
   searchTimePeriodByGroup: {
     fromToGroupSQL: `SELECT count(*)::INTEGER
 FROM lev_audit
-WHERE date_time::DATE >= $(from) AND date_time::DATE < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%'`,
+WHERE date_time >= $(from) AND date_time < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%'`,
     gorupOnlySQL: `SELECT count(*)::INTEGER
 FROM lev_audit
 WHERE groups::TEXT ILIKE '%' || $(group) || '%'`

--- a/test/server/lib/db/query.fixtures.js
+++ b/test/server/lib/db/query.fixtures.js
@@ -1,5 +1,10 @@
 
 module.exports = {
+  searchTotals: {
+    totalCountSQL: `SELECT count(*)::INTEGER FROM lev_audit`,
+    todayCountSQL: `SELECT count(*)::INTEGER FROM lev_audit WHERE date_time::DATE = current_date`
+  },
+
   searchTimePeriodByGroup: {
     fromToGroupSQL: `SELECT count(*)::INTEGER
 FROM lev_audit

--- a/test/server/lib/db/query.fixtures.js
+++ b/test/server/lib/db/query.fixtures.js
@@ -1,0 +1,11 @@
+
+module.exports = {
+  searchTimePeriodByGroup: {
+    fromToGroupSQL: `SELECT count(*)::INTEGER
+FROM lev_audit
+WHERE date_time::DATE >= $(from) AND date_time::DATE < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%'`,
+    gorupOnlySQL: `SELECT count(*)::INTEGER
+FROM lev_audit
+WHERE groups::TEXT ILIKE '%' || $(group) || '%'`
+  }
+};

--- a/test/server/lib/db/query.fixtures.js
+++ b/test/server/lib/db/query.fixtures.js
@@ -3,12 +3,12 @@ module.exports = {
   usageByDateType: {
     fromDateOnlySQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
+WHERE date_time >= $(from)
 GROUP BY date, dataset
 ORDER BY date`,
     allParametersSQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London' AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London' AND groups::TEXT ILIKE '%' || $(group) || '%'
+WHERE date_time >= $(from) AND date_time < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%'
 GROUP BY date, dataset
 ORDER BY date`
   },
@@ -16,11 +16,11 @@ ORDER BY date`
   usageByType: {
     fromDateSQL: `SELECT dataset, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
+WHERE date_time >= $(from)
 GROUP BY dataset`,
     fromToSQL: `SELECT dataset, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London' AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London'
+WHERE date_time >= $(from) AND date_time < $(to)
 GROUP BY dataset`
   },
 
@@ -30,12 +30,12 @@ SELECT name, dataset, SUM(count)::INTEGER AS count
 FROM (
   SELECT UNNEST(groups) AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
+    WHERE date_time >= $(from)
     GROUP BY name, dataset 
   UNION
   SELECT 'No group' AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE groups='{}' AND date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
+    WHERE groups='{}' AND date_time >= $(from)
     GROUP BY name, dataset
 ) AS counts
 GROUP BY name, dataset
@@ -45,14 +45,14 @@ SELECT name, dataset, SUM(count)::INTEGER AS count
 FROM (
   SELECT UNNEST(groups) AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
-      AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London'
+    WHERE date_time >= $(from)
+      AND date_time < $(to)
     GROUP BY name, dataset 
   UNION
   SELECT 'No group' AS name, dataset, COUNT(*)
     FROM lev_audit
-    WHERE groups='{}' AND date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
-      AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London'
+    WHERE groups='{}' AND date_time >= $(from)
+      AND date_time < $(to)
     GROUP BY name, dataset
 ) AS counts
 GROUP BY name, dataset
@@ -62,12 +62,12 @@ ORDER BY name~'^/Team' desc, name`
   usageByUser: {
     fromDateSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London'
+WHERE date_time >= $(from)
 GROUP BY date, dataset, username
 ORDER BY date`,
     fromToSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London' AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London'
+WHERE date_time >= $(from) AND date_time < $(to)
 GROUP BY date, dataset, username
 ORDER BY date`
   },
@@ -80,7 +80,7 @@ ORDER BY date`
   searchTimePeriodByGroup: {
     fromToGroupSQL: `SELECT count(*)::INTEGER
 FROM lev_audit
-WHERE date_time >= ($(from)::timestamp without time zone) at time zone 'Europe/London' AND date_time < ($(to)::timestamp without time zone) at time zone 'Europe/London' AND groups::TEXT ILIKE '%' || $(group) || '%'`,
+WHERE date_time >= $(from) AND date_time < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%'`,
     gorupOnlySQL: `SELECT count(*)::INTEGER
 FROM lev_audit
 WHERE groups::TEXT ILIKE '%' || $(group) || '%'`

--- a/test/server/lib/db/query.fixtures.js
+++ b/test/server/lib/db/query.fixtures.js
@@ -1,5 +1,53 @@
 
 module.exports = {
+  usageByDateType: {
+    fromDateOnlySQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER FROM lev_audit WHERE date_time::DATE >= $(from) GROUP BY date_time::date, dataset ORDER BY date_time::date`,
+    allParametersSQL: `SELECT date_time::DATE AS date, dataset, count(*)::INTEGER FROM lev_audit WHERE date_time::DATE >= $(from) AND date_time::DATE < $(to) AND groups::TEXT ILIKE '%' || $(group) || '%' GROUP BY date_time::date, dataset ORDER BY date_time::date`
+  },
+
+  usageByType: {
+    fromDateSQL: `SELECT dataset, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from)   GROUP BY dataset`,
+    fromToSQL: `SELECT dataset, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from) AND date_time < $(to)  GROUP BY dataset`
+  },
+
+  usageByGroup: {
+    fromDateSQL: `
+SELECT name, dataset, SUM(count)::INTEGER AS count
+FROM (
+  SELECT UNNEST(groups) AS name, dataset, COUNT(*)
+    FROM lev_audit
+    WHERE date_time > $(from) 
+    GROUP BY name, dataset 
+  UNION
+  SELECT 'No group' AS name, dataset, COUNT(*)
+    FROM lev_audit
+    WHERE groups='{}' AND date_time > $(from) 
+    GROUP BY name, dataset
+) AS counts
+GROUP BY name, dataset
+ORDER BY name~'^/Team' desc, name`,
+    fromToSQL: `
+SELECT name, dataset, SUM(count)::INTEGER AS count
+FROM (
+  SELECT UNNEST(groups) AS name, dataset, COUNT(*)
+    FROM lev_audit
+    WHERE date_time > $(from) AND date_time < $(to)
+    GROUP BY name, dataset 
+  UNION
+  SELECT 'No group' AS name, dataset, COUNT(*)
+    FROM lev_audit
+    WHERE groups='{}' AND date_time > $(from) AND date_time < $(to)
+    GROUP BY name, dataset
+) AS counts
+GROUP BY name, dataset
+ORDER BY name~'^/Team' desc, name`
+  },
+
+  usageByUser: {
+    fromDateSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from)   GROUP BY date_time::date, dataset, username ORDER BY date_time::date`,
+    fromToSQL: `SELECT date_time::DATE AS date, dataset, username, count(*)::INTEGER FROM lev_audit WHERE date_time > $(from) AND date_time < $(to)  GROUP BY date_time::date, dataset, username ORDER BY date_time::date`
+  },
+
   searchTotals: {
     totalCountSQL: `SELECT count(*)::INTEGER FROM lev_audit`,
     todayCountSQL: `SELECT count(*)::INTEGER FROM lev_audit WHERE date_time::DATE = current_date`

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const proxyquire = require('proxyquire');
+const timeshift = require('timeshift');
 const fixtures = require('./query.fixtures');
 const rewire = require('rewire');
 const query = rewire('../../../../src/lib/db/query');
@@ -251,12 +252,14 @@ describe('lib/db/query', () => {
 		describe('when `false` is provided', () => {
 			before(() => {
 				stubs.one.resetHistory();
+				timeshift('2020-06-06');
 				fakeQuery.searchTotals(false);
 			});
-			it('should pass SQL to the database library with the "today" where clause', () =>
+			it('should pass SQL to the database library with the timestamp for the beginning of the day', () =>
 				expect(stubs.one).to.have.been.calledOnce
-					.and.to.have.been.calledWith(fixtures.searchTotals.todayCountSQL)
+					.and.to.have.been.calledWith(fixtures.searchTotals.todayCountSQL, ['2020-06-06T00:00:00+01:00'])
 			);
+			after('restore current time', () => timeshift());
 		});
 	});
 

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -136,6 +136,106 @@ describe('lib/db/query', () => {
 		});
 	});
 
+	describe('usageByDateType', () => {
+		const from = 'yesterday', to = 'today', group = 'group';
+		describe('when called with from date', () => {
+			before(() => {
+				stubs.manyOrNone.resetHistory();
+				fakeQuery.usageByDateType(from);
+			});
+			it('should build an SQL statement with `from` date filter', () =>
+				expect(stubs.manyOrNone).to.have.been.calledOnce
+					.and.to.have.been.calledWith(fixtures.usageByDateType.fromDateOnlySQL, { from })
+			);
+
+			describe('and to date, and group', () => {
+				before(() => {
+					stubs.manyOrNone.resetHistory();
+					fakeQuery.usageByDateType(from, to, group);
+				});
+				it('should build an SQL statement with `from`/`to` date and `group` filters', () =>
+					expect(stubs.manyOrNone).to.have.been.calledOnce
+						.and.to.have.been.calledWith(fixtures.usageByDateType.allParametersSQL, { from, to, group })
+				);
+			});
+		});
+	});
+
+	describe('usageByType', () => {
+		const from = 'yesterday', to = 'today';
+		describe('when called with from date', () => {
+			before(() => {
+				stubs.manyOrNone.resetHistory();
+				fakeQuery.usageByType(from);
+			});
+			it('should build an SQL statement with `from` date filter', () =>
+				expect(stubs.manyOrNone).to.have.been.calledOnce
+					.and.to.have.been.calledWith(fixtures.usageByType.fromDateSQL, { from })
+			);
+
+			describe('and to date, and group', () => {
+				before(() => {
+					stubs.manyOrNone.resetHistory();
+					fakeQuery.usageByType(from, to);
+				});
+				it('should build an SQL statement with `from`/`to` date filters', () =>
+					expect(stubs.manyOrNone).to.have.been.calledOnce
+						.and.to.have.been.calledWith(fixtures.usageByType.fromToSQL, { from, to })
+				);
+			});
+		});
+	});
+
+	describe('usageByGroup', () => {
+		const from = 'yesterday', to = 'today';
+		describe('when called with from date', () => {
+			before(() => {
+				stubs.manyOrNone.resetHistory();
+				fakeQuery.usageByGroup(from);
+			});
+			it('should build an SQL statement with `from` date filter', () =>
+				expect(stubs.manyOrNone).to.have.been.calledOnce
+					.and.to.have.been.calledWith(fixtures.usageByGroup.fromDateSQL, { from })
+			);
+
+			describe('and to date, and group', () => {
+				before(() => {
+					stubs.manyOrNone.resetHistory();
+					fakeQuery.usageByGroup(from, to);
+				});
+				it('should build an SQL statement with `from`/`to` date filters', () =>
+					expect(stubs.manyOrNone).to.have.been.calledOnce
+						.and.to.have.been.calledWith(fixtures.usageByGroup.fromToSQL, { from, to })
+				);
+			});
+		});
+	});
+
+	describe('usageByUser', () => {
+		const from = 'yesterday', to = 'today';
+		describe('when called with from date', () => {
+			before(() => {
+				stubs.manyOrNone.resetHistory();
+				fakeQuery.usageByUser(from);
+			});
+			it('should build an SQL statement with `from` date filter', () =>
+				expect(stubs.manyOrNone).to.have.been.calledOnce
+					.and.to.have.been.calledWith(fixtures.usageByUser.fromDateSQL, { from })
+			);
+
+			describe('and to date, and group', () => {
+				before(() => {
+					stubs.manyOrNone.resetHistory();
+					fakeQuery.usageByUser(from, to);
+				});
+				it('should build an SQL statement with `from`/`to` date filters', () =>
+					expect(stubs.manyOrNone).to.have.been.calledOnce
+						.and.to.have.been.calledWith(fixtures.usageByUser.fromToSQL, { from, to })
+				);
+			});
+		});
+	});
+
 	describe('searchTotals function', () => {
 		describe('when `true` is provided', () => {
 			before(() => {

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -108,6 +108,24 @@ describe('lib/db/query', () => {
 							.to.be.a('string')
 							.that.equals('SELECT first_name, surname, COUNT(*) FROM aTable GROUP BY first_name, surname')
 					);
+					it('should return the same query, using the specified "joiner" character', () =>
+						expect(fn({
+							'SELECT': 'first_name, surname, COUNT(*)',
+							'FROM': 'aTable',
+							'GROUP BY': 'first_name, surname'
+						}, '\n'))
+							.to.be.a('string')
+							.that.equals('SELECT first_name, surname, COUNT(*)\nFROM aTable\nGROUP BY first_name, surname')
+					);
+					it('should return the same query, using the specified "joiner" string', () =>
+						expect(fn({
+							'SELECT': 'first_name, surname, COUNT(*)',
+							'FROM': 'aTable',
+							'GROUP BY': 'first_name, surname'
+						}, '\n  '))
+							.to.be.a('string')
+							.that.equals('SELECT first_name, surname, COUNT(*)\n  FROM aTable\n  GROUP BY first_name, surname')
+					);
 				});
 			});
 		});

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -137,10 +137,6 @@ describe('lib/db/query', () => {
 	});
 
 	describe('searchTotals function', () => {
-		// eslint-disable-next-line no-underscore-dangle
-		const totalCountSQL = query.__get__('totalCount');
-		// eslint-disable-next-line no-underscore-dangle
-		const forTodaySQL = query.__get__('forToday');
 		describe('when `true` is provided', () => {
 			before(() => {
 				stubs.one.resetHistory();
@@ -148,7 +144,7 @@ describe('lib/db/query', () => {
 			});
 			it('should pass SQL to the database library', () =>
 				expect(stubs.one).to.have.been.calledOnce
-					.and.to.have.been.calledWith(totalCountSQL)
+					.and.to.have.been.calledWith(fixtures.searchTotals.totalCountSQL)
 			);
 		});
 
@@ -159,7 +155,7 @@ describe('lib/db/query', () => {
 			});
 			it('should pass SQL to the database library with the "today" where clause', () =>
 				expect(stubs.one).to.have.been.calledOnce
-					.and.to.have.been.calledWith(totalCountSQL + forTodaySQL)
+					.and.to.have.been.calledWith(fixtures.searchTotals.todayCountSQL)
 			);
 		});
 	});

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -141,29 +141,22 @@ describe('lib/db/query', () => {
 		const totalCountSQL = query.__get__('totalCount');
 		// eslint-disable-next-line no-underscore-dangle
 		const forTodaySQL = query.__get__('forToday');
-		before(() => {
-			stubs.one.resetHistory();
-		});
 		describe('when `true` is provided', () => {
-			it('should return a promise', () =>
-				expect(fakeQuery.searchTotals(true))
-					.to.be.an.instanceOf(Promise)
-					.that.is.fulfilled
-			);
+			before(() => {
+				stubs.one.resetHistory();
+				fakeQuery.searchTotals(true);
+			});
 			it('should pass SQL to the database library', () =>
 				expect(stubs.one).to.have.been.calledOnce
 					.and.to.have.been.calledWith(totalCountSQL)
 			);
 		});
+
 		describe('when `false` is provided', () => {
 			before(() => {
 				stubs.one.resetHistory();
+				fakeQuery.searchTotals(false);
 			});
-			it('should return a promise', () =>
-				expect(fakeQuery.searchTotals(false))
-					.to.be.an.instanceOf(Promise)
-					.that.is.fulfilled
-			);
 			it('should pass SQL to the database library with the "today" where clause', () =>
 				expect(stubs.one).to.have.been.calledOnce
 					.and.to.have.been.calledWith(totalCountSQL + forTodaySQL)
@@ -177,27 +170,17 @@ describe('lib/db/query', () => {
 		const group = 'HMRC';
 		before(() => {
 			stubs.one.resetHistory();
+			fakeQuery.searchTimePeriodByGroup(dateFrom, dateTo, group);
 		});
-		describe('when function is called with arguments', () => {
-			it('should return a promise', () =>
-				expect(fakeQuery.searchTimePeriodByGroup(dateFrom, dateTo, group))
-					.to.be.an.instanceOf(Promise)
-					.that.is.fulfilled
-			);
-			it('should build an sql statement when `to, from and group` are provided', () =>
-				expect(stubs.one).to.have.been.calledOnce
-					.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.fromToGroupSQL)
-			);
-		});
+		it('should build an sql statement when `to, from and group` are provided', () =>
+			expect(stubs.one).to.have.been.calledOnce
+				.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.fromToGroupSQL)
+		);
 		describe('when function is called with empty dates', () => {
 			before(() => {
 				stubs.one.resetHistory();
+				fakeQuery.searchTimePeriodByGroup('', '', group);
 			});
-			it('should return a promise', () =>
-				expect(fakeQuery.searchTimePeriodByGroup('', '', group))
-					.to.be.an.instanceOf(Promise)
-					.that.is.fulfilled
-			);
 			it('should build an sql statement when to and from dates are not provided', () =>
 				expect(stubs.one).to.have.been.calledOnce
 					.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.gorupOnlySQL)

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const proxyquire = require('proxyquire');
+const fixtures = require('./query.fixtures');
 const rewire = require('rewire');
 const query = rewire('../../../../src/lib/db/query');
 
@@ -193,9 +194,7 @@ describe('lib/db/query', () => {
 			);
 			it('should build an sql statement when `to, from and group` are provided', () =>
 				expect(stub).to.have.been.calledOnce
-					.and.to.have.been.calledWith('SELECT count(*)::INTEGER FROM lev_audit ' +
-					'WHERE date_time::DATE >= $(from) AND date_time::DATE < $(to) ' +
-					'AND groups::TEXT ILIKE \'%\' || $(group) || \'%\'')
+					.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.fromToGroupSQL)
 			);
 		});
 		describe('when function is called with empty dates', () => {
@@ -209,8 +208,7 @@ describe('lib/db/query', () => {
 			);
 			it('should build an sql statement when to and from dates are not provided', () =>
 				expect(stub).to.have.been.calledOnce
-					.and.to.have.been.calledWith('SELECT count(*)::INTEGER FROM lev_audit ' +
-					'WHERE groups::TEXT ILIKE \'%\' || $(group) || \'%\'')
+					.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.gorupOnlySQL)
 			);
 		});
 	});

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -100,33 +100,30 @@ describe('lib/db/query', () => {
 				});
 
 				describe('select with grouping', () => {
+					const sqlObj = {
+						'SELECT': 'first_name, surname, COUNT(*)',
+						'FROM': 'aTable',
+						'GROUP BY': 'first_name, surname'
+					};
+
 					it('should return a query, built from the select, from and grouping fields', () =>
-						expect(fn({
-							'SELECT': 'first_name, surname, COUNT(*)',
-							'FROM': 'aTable',
-							'GROUP BY': 'first_name, surname'
-						}))
+						expect(fn(sqlObj))
 							.to.be.a('string')
 							.that.equals('SELECT first_name, surname, COUNT(*) FROM aTable GROUP BY first_name, surname')
 					);
-					it('should return the same query, using the specified "joiner" character', () =>
-						expect(fn({
-							'SELECT': 'first_name, surname, COUNT(*)',
-							'FROM': 'aTable',
-							'GROUP BY': 'first_name, surname'
-						}, '\n'))
-							.to.be.a('string')
-							.that.equals('SELECT first_name, surname, COUNT(*)\nFROM aTable\nGROUP BY first_name, surname')
-					);
-					it('should return the same query, using the specified "joiner" string', () =>
-						expect(fn({
-							'SELECT': 'first_name, surname, COUNT(*)',
-							'FROM': 'aTable',
-							'GROUP BY': 'first_name, surname'
-						}, '\n  '))
-							.to.be.a('string')
-							.that.equals('SELECT first_name, surname, COUNT(*)\n  FROM aTable\n  GROUP BY first_name, surname')
-					);
+
+					describe('when a custom "joiner" is specified', () => {
+						it('should return the same query, using the specified "joiner" character', () =>
+							expect(fn(sqlObj, '\n'))
+								.to.be.a('string')
+								.that.equals('SELECT first_name, surname, COUNT(*)\nFROM aTable\nGROUP BY first_name, surname')
+						);
+						it('should return the same query, using the specified "joiner" string', () =>
+							expect(fn(sqlObj, '\n  '))
+								.to.be.a('string')
+								.that.equals('SELECT first_name, surname, COUNT(*)\n  FROM aTable\n  GROUP BY first_name, surname')
+						);
+					});
 				});
 			});
 		});

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -4,6 +4,13 @@ const proxyquire = require('proxyquire');
 const fixtures = require('./query.fixtures');
 const rewire = require('rewire');
 const query = rewire('../../../../src/lib/db/query');
+const stubs = {
+	one: sinon.stub().resolves(),
+	manyOrNone: sinon.stub().resolves()
+};
+const fakeQuery = proxyquire('../../../../src/lib/db/query', {
+	'./postgres': stubs
+});
 
 describe('lib/db/query', () => {
 	describe('helper functions', () => {
@@ -134,14 +141,8 @@ describe('lib/db/query', () => {
 		const totalCountSQL = query.__get__('totalCount');
 		// eslint-disable-next-line no-underscore-dangle
 		const forTodaySQL = query.__get__('forToday');
-		let fakeQuery;
-		let stub;
 		before(() => {
-			stub = sinon.stub();
-			stub.returns(Promise.resolve());
-			fakeQuery = proxyquire('../../../../src/lib/db/query', {
-				'./postgres': { one: stub }
-			});
+			stubs.one.resetHistory();
 		});
 		describe('when `true` is provided', () => {
 			it('should return a promise', () =>
@@ -150,13 +151,13 @@ describe('lib/db/query', () => {
 					.that.is.fulfilled
 			);
 			it('should pass SQL to the database library', () =>
-				expect(stub).to.have.been.calledOnce
+				expect(stubs.one).to.have.been.calledOnce
 					.and.to.have.been.calledWith(totalCountSQL)
 			);
 		});
 		describe('when `false` is provided', () => {
 			before(() => {
-				stub.resetHistory();
+				stubs.one.resetHistory();
 			});
 			it('should return a promise', () =>
 				expect(fakeQuery.searchTotals(false))
@@ -164,7 +165,7 @@ describe('lib/db/query', () => {
 					.that.is.fulfilled
 			);
 			it('should pass SQL to the database library with the "today" where clause', () =>
-				expect(stub).to.have.been.calledOnce
+				expect(stubs.one).to.have.been.calledOnce
 					.and.to.have.been.calledWith(totalCountSQL + forTodaySQL)
 			);
 		});
@@ -174,14 +175,8 @@ describe('lib/db/query', () => {
 		const dateFrom = '2000-01-30';
 		const dateTo = '2000-02-02';
 		const group = 'HMRC';
-		let fakeQuery;
-		let stub;
 		before(() => {
-			stub = sinon.stub();
-			stub.returns(Promise.resolve());
-			fakeQuery = proxyquire('../../../../src/lib/db/query', {
-				'./postgres': { one: stub }
-			});
+			stubs.one.resetHistory();
 		});
 		describe('when function is called with arguments', () => {
 			it('should return a promise', () =>
@@ -190,13 +185,13 @@ describe('lib/db/query', () => {
 					.that.is.fulfilled
 			);
 			it('should build an sql statement when `to, from and group` are provided', () =>
-				expect(stub).to.have.been.calledOnce
+				expect(stubs.one).to.have.been.calledOnce
 					.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.fromToGroupSQL)
 			);
 		});
 		describe('when function is called with empty dates', () => {
 			before(() => {
-				stub.resetHistory();
+				stubs.one.resetHistory();
 			});
 			it('should return a promise', () =>
 				expect(fakeQuery.searchTimePeriodByGroup('', '', group))
@@ -204,7 +199,7 @@ describe('lib/db/query', () => {
 					.that.is.fulfilled
 			);
 			it('should build an sql statement when to and from dates are not provided', () =>
-				expect(stub).to.have.been.calledOnce
+				expect(stubs.one).to.have.been.calledOnce
 					.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.gorupOnlySQL)
 			);
 		});

--- a/test/server/lib/db/query.js
+++ b/test/server/lib/db/query.js
@@ -165,16 +165,16 @@ describe('lib/db/query', () => {
 	});
 
 	describe('searchTimePeriodByGroup function', () => {
-		const dateFrom = '2000-01-30';
-		const dateTo = '2000-02-02';
+		const from = '2000-01-30';
+		const to = '2000-02-02';
 		const group = 'HMRC';
 		before(() => {
 			stubs.one.resetHistory();
-			fakeQuery.searchTimePeriodByGroup(dateFrom, dateTo, group);
+			fakeQuery.searchTimePeriodByGroup(from, to, group);
 		});
 		it('should build an sql statement when `to, from and group` are provided', () =>
 			expect(stubs.one).to.have.been.calledOnce
-				.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.fromToGroupSQL)
+				.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.fromToGroupSQL, { from, to, group })
 		);
 		describe('when function is called with empty dates', () => {
 			before(() => {
@@ -183,7 +183,7 @@ describe('lib/db/query', () => {
 			});
 			it('should build an sql statement when to and from dates are not provided', () =>
 				expect(stubs.one).to.have.been.calledOnce
-					.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.gorupOnlySQL)
+					.and.to.have.been.calledWith(fixtures.searchTimePeriodByGroup.gorupOnlySQL, { group })
 			);
 		});
 	});

--- a/test/server/lib/route-helpers.js
+++ b/test/server/lib/route-helpers.js
@@ -1,17 +1,17 @@
 'use strict';
 
 const rewire = require('rewire');
-const routes = rewire('../../../src/lib/routes');
+const routeHelpers = rewire('../../../src/lib/route-helpers');
 
-describe('lib/routes', () => {
+describe('lib/routesHelpers', () => {
 	describe('helper functions', () => {
 		describe('dateChecker', () => {
 			// eslint-disable-next-line no-underscore-dangle
-			const fn = routes.__get__('dateChecker');
+			const fn = routeHelpers.__get__('dateChecker');
 			describe('checks for invalid dates', () => {
 				it('should return false when the input is not a valid date', () =>
 					expect(fn('2019-09-50'))
-						.to.be.false
+						.to.be.null
 				);
 			});
 			describe('checks for valid dates', () => {
@@ -25,5 +25,9 @@ describe('lib/routes', () => {
 				});
 			});
 		});
+	});
+
+	describe('home page', () => {
+
 	});
 });

--- a/test/server/lib/route-helpers.js
+++ b/test/server/lib/route-helpers.js
@@ -1,33 +1,126 @@
 'use strict';
 
-const rewire = require('rewire');
-const routeHelpers = rewire('../../../src/lib/route-helpers');
+const moment = require('moment');
+const timeshift = require('timeshift');
+const stub = sinon.stub().resolves('finished');
+const { dateChecker, promiseResponder, dashboard, home } = require('proxyquire')('../../../src/lib/route-helpers', {
+	'./model': stub
+});
 
 describe('lib/routesHelpers', () => {
-	describe('helper functions', () => {
-		describe('dateChecker', () => {
-			// eslint-disable-next-line no-underscore-dangle
-			const fn = routeHelpers.__get__('dateChecker');
+	describe('dateChecker', () => {
 			describe('checks for invalid dates', () => {
-				it('should return false when the input is not a valid date', () =>
-					expect(fn('2019-09-50'))
-						.to.be.null
-				);
+				it('should return "Invalid date" when the input is not a valid date', () =>
+					expect(dateChecker('2019-09-50'))
+						.to.equal('Invalid date'));
 			});
 			describe('checks for valid dates', () => {
-				it('should return an ISO formatted timestamp string when the input is a valid date', ()=> {
-					expect(fn('2019-06-03'))
+				it('should return an ISO formatted timestamp string', ()=> {
+					expect(dateChecker('2019-06-03'))
 						.to.be.a('string')
-						.and.to.equal('2019-06-02T23:00:00.000Z');
-					expect(fn('2019-12-03'))
+						.and.to.equal('2019-06-03T00:00:00+01:00');
+					expect(dateChecker('2019-12-03'))
 						.to.be.a('string')
-						.and.to.equal('2019-12-03T00:00:00.000Z');
+						.and.to.equal('2019-12-03T00:00:00Z');
 				});
 			});
 		});
+
+	describe('promiseResponder', () => {
+		const next = sinon.stub();
+		const render = sinon.stub();
+		const send = sinon.stub();
+		const args = [Promise.resolve('data'), {}, { render, send }, next];
+		it('should return a promise', () =>
+			expect(promiseResponder(...args))
+				.to.be.an.instanceOf(Promise)
+				.that.is.fulfilled);
+		it('should have send promise data', () =>
+			expect(send)
+				.to.have.been.calledOnce
+				.and.to.have.been.calledWith('data'));
+		describe('when a component is provided', () => {
+			before(() => promiseResponder(...args, 'component'));
+			it('should render the component with the data', () =>
+				expect(render)
+					.to.have.been.calledOnce
+					.and.to.have.been.calledWith('component', 'data'));
+		});
 	});
 
-	describe('home page', () => {
+	describe('home', () => {
+		describe('checks query string inputs and passes filter values to the model', () => {
+			describe('during a GMT month', () => {
+				before('e.g. December', () => timeshift('2020-12-14'));
+				describe('when no dates are provided', () => {
+					it('should fetch model data', () =>
+						expect(home({}))
+							.to.be.an.instanceOf(Promise)
+							.that.eventually.equal('finished'));
+					it('should request model data from the start of the month', () =>
+						expect(stub)
+							.to.have.been.calledOnce
+							.and.to.have.been.calledWith('2020-12-01T00:00:00Z', false));
+				});
+				describe('when dates are provided', () => {
+					before(() => stub.resetHistory());
+					it('should fetch model data', () =>
+						expect(home({ from: '2020-12-07', to: '2020-12-12' }))
+							.to.be.an.instanceOf(Promise)
+							.that.eventually.equal('finished'));
+					it('should request model data from the given range', () =>
+						expect(stub)
+							.to.have.been.calledOnce
+							.and.to.have.been.calledWith('2020-12-07T00:00:00Z', '2020-12-12T00:00:00Z'));
+				});
+				after('restore current time', () => timeshift());
+			});
 
+			describe('during a BST month', () => {
+				before('e.g. June', () => timeshift('2020-06-06'));
+				describe('when no dates are provided', () => {
+					before(() => stub.resetHistory());
+					it('should fetch model data', () =>
+						expect(home({}))
+							.to.be.an.instanceOf(Promise)
+							.that.eventually.equal('finished'));
+					it('should request model data from the start of the month', () =>
+						expect(stub)
+							.to.have.been.calledOnce
+							.and.to.have.been.calledWith('2020-06-01T00:00:00+01:00', false));
+				});
+				describe('when dates are provided', () => {
+					before(() => stub.resetHistory());
+					it('should fetch model data', () =>
+						expect(home({ from: '2020-06-07', to: '2020-06-12' }))
+							.to.be.an.instanceOf(Promise)
+							.that.eventually.equal('finished'));
+					it('should request model data from the given range', () =>
+						expect(stub)
+							.to.have.been.calledOnce
+							.and.to.have.been.calledWith('2020-06-07T00:00:00+01:00', '2020-06-12T00:00:00+01:00'));
+				});
+				after('restore current time', () => timeshift());
+			});
+
+			describe('when a group is specified', () => {
+				before(() => stub.resetHistory());
+				it('should fetch model data', () =>
+					expect(home({ currentGroup: 'a group' }))
+						.to.be.an.instanceOf(Promise)
+						.that.eventually.equal('finished'));
+				it('should request model data from the given range', () =>
+					expect(stub)
+						.to.have.been.calledOnce
+						.and.to.have.been.calledWith(stub.firstCall.args[0], false, 'a group', 'a group'));
+			});
+
+			describe('when an error constructor is provided', () => {
+				it('should fail with an error when passed a bunk date', () =>
+					expect(home({ from: '2020-20-20' }, Error))
+						.to.be.an.instanceOf(Promise)
+						.that.is.eventually.rejectedWith(Error, 'Must provide "from" date parameter, and optionally a "to" date'));
+			});
+		});
 	});
 });

--- a/test/server/lib/routes.js
+++ b/test/server/lib/routes.js
@@ -15,10 +15,13 @@ describe('lib/routes', () => {
 				);
 			});
 			describe('checks for valid dates', () => {
-				it('should return an ISO formatted date string when the input is a valid date', ()=> {
-					expect(fn('2019-09-03'))
+				it('should return an ISO formatted timestamp string when the input is a valid date', ()=> {
+					expect(fn('2019-06-03'))
 						.to.be.a('string')
-						.and.to.equal('2019-09-03');
+						.and.to.equal('2019-06-02T23:00:00.000Z');
+					expect(fn('2019-12-03'))
+						.to.be.a('string')
+						.and.to.equal('2019-12-03T00:00:00.000Z');
 				});
 			});
 		});


### PR DESCRIPTION
Assume dates/times are entered based on the `Europe/London` timezone, and as such, should be sent to the DB as complete exacting timestamps to avoid errors from timezone differences.

NOTE: because this issue effects all the queries, this seems like a good opportunity to add some tests as well.
This PR also tries to speed up the queries by comparing timestamps against the `date_time` column, so we no longer do any slow and unnecessary conversions of that column.